### PR TITLE
Configuring CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,9 @@
+version: 2.1
+
+orbs:
+  maven: circleci/maven@0.0.12
+
+workflows:
+  maven_test:
+    jobs:
+      - maven/test # checkout, build, test, and upload test results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,30 @@
 version: 2.1
 
+executors:
+  openjdk8:
+    docker:
+      - image: maven:3.6-jdk-8
+
 orbs:
-  maven: circleci/maven@0.0.12
+  maven: circleci/maven@1.0.0
 
 workflows:
-  maven_test:
+  build_test_deploy:
     jobs:
-      - maven/test # checkout, build, test, and upload test results
+      - maven/test:
+          executor: openjdk8
+          command: -s mvnsettings.xml deploy
+          context: tm4j
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+/
+            branches:
+              ignore: /.*/
+
+  build_test:
+    jobs:
+      - maven/test:
+          executor: openjdk8
+          filters:
+            tags:
+              ignore: /^\d+\.\d+\.\d+/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,3 @@ workflows:
     jobs:
       - maven/test:
           executor: openjdk8
-          filters:
-            tags:
-              ignore: /^\d+\.\d+\.\d+/

--- a/mvnsettings.xml
+++ b/mvnsettings.xml
@@ -4,8 +4,8 @@
     <servers>
         <server>
             <id>maven.jenkins-ci.org</id>
-            <username>${jenkinsci.user}</username>
-            <password>${jenkinsci.password}</password>
+            <username>${JENKINS_ARTIFACTORY_USER}</username>
+            <password>${JENKINS_ARTIFACTORY_PASSWORD}</password>
         </server>
     </servers>
 </settings>


### PR DESCRIPTION
Configures CircleCI builds.

When a tag is created respecting semantic versioning, the build will trigger to compile, run tests and deploy a new version to the jenkinsci Artifactory. For regular branches and commits, a new build is triggered too, but only for compiling and testing.