### PR TITLE
Fix temporary directory creation/deletion

### DIFF
--- a/src/main/java/com/adaptavist/tm4j/jenkins/cucumber/CucumberFileProcessor.java
+++ b/src/main/java/com/adaptavist/tm4j/jenkins/cucumber/CucumberFileProcessor.java
@@ -39,7 +39,7 @@ public class CucumberFileProcessor {
         File directory = new File(tmpDirectory);
 
         if (!directory.exists()) {
-            if (!directory.mkdir()) {
+            if (!directory.mkdirs()) {
                 throw new RuntimeException(String.format("The directory '%s' couldn't be created. Please check " +
                         "folder permissions and try again", tmpDirectory));
             }

--- a/src/main/java/com/adaptavist/tm4j/jenkins/cucumber/CucumberFileProcessor.java
+++ b/src/main/java/com/adaptavist/tm4j/jenkins/cucumber/CucumberFileProcessor.java
@@ -76,7 +76,6 @@ public class CucumberFileProcessor {
     }
 
     public void deleteTmpFilesAndFolder() {
-        String tmpDirectory = getTmpDirectory(this.tmpDirectory);
         File directoryFile = new File(tmpDirectory);
         File[] allContents = directoryFile.listFiles();
         if (allContents != null) {

--- a/src/test/java/com/adaptavist/tm4j/jenkins/cucumber/CucumberReportParserTest.java
+++ b/src/test/java/com/adaptavist/tm4j/jenkins/cucumber/CucumberReportParserTest.java
@@ -1,6 +1,7 @@
 package com.adaptavist.tm4j.jenkins.cucumber;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -16,7 +17,12 @@ public class CucumberReportParserTest {
     @Before
     public void setUp(){
         cucumberFileProcessor = new CucumberFileProcessor(System.out, "");
-        cucumberFileProcessor.setTmpDirectory("tmp");
+        cucumberFileProcessor.setTmpDirectory("tmp/subdir");
+    }
+
+    @After
+    public void tearDown(){
+        cucumberFileProcessor.deleteTmpFilesAndFolder();
     }
 
     @Test


### PR DESCRIPTION
We have started getting publish failures along the lines of
`The directory '/var/jenkins_home/jobs/<snip>/builds/1/target/cucumber_tmp/' couldn't be created. Please check folder permissions and try again  `

If we manually create the `target` folder first we then get an error along the lines of
`The generated directory couldn't be deleted. Please check folder permissions and delete the directory manually: /var/jenkins_home/jobs/<snip>/builds/1/target/cucumber_tmp/target/cucumber_tmp' `

It looks like the introduction of a subdirectory into the tmpDirectory path causes mkdir to fail as it doesn't create non-existent parents, and the deletion fails as tmpDirectory has already been through getTmpDirectory once, sending it through again results in the path being duplicated.

This PR should resolve both those issues. The test has been tweaked to cover this scenario (fails without this PR, passes with it)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
