### PR TITLE
Expand environment variables in custom test cycle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <description>Integration with Zephyr Scale (by SmartBear), for automatic publishing of test results.</description>
     <groupId>com.adaptavist</groupId>
     <artifactId>tm4j-automation</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
     <packaging>hpi</packaging>
 
     <licenses>

--- a/src/main/java/com/adaptavist/tm4j/jenkins/extensions/CustomTestCycle.java
+++ b/src/main/java/com/adaptavist/tm4j/jenkins/extensions/CustomTestCycle.java
@@ -2,19 +2,15 @@ package com.adaptavist.tm4j.jenkins.extensions;
 
 import static org.apache.commons.lang.StringUtils.isBlank;
 
-import com.adaptavist.tm4j.jenkins.utils.GsonUtils;
-import com.google.gson.reflect.TypeToken;
 import hudson.EnvVars;
-import java.util.HashMap;
-import java.util.Map;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class CustomTestCycle {
     protected String name;
     protected String description;
-    protected Long jiraProjectVersion;
-    protected Long folderId;
-    protected Map<String, Object> customFields;
+    protected String jiraProjectVersion;
+    protected String folderId;
+    protected String customFields;
 
     @DataBoundConstructor
     public CustomTestCycle(
@@ -24,11 +20,11 @@ public class CustomTestCycle {
         final String folderId,
         final String customFields
     ) {
-        this.name = setStringIfNotBlank(name);
-        this.description = setStringIfNotBlank(description);
-        this.jiraProjectVersion = jiraProjectVersion(jiraProjectVersion);
-        this.folderId = jiraProjectVersion(folderId);
-        this.customFields = convertCustomFieldsToMapIfValid(customFields);
+        this.name = name;
+        this.description = description;
+        this.jiraProjectVersion = jiraProjectVersion;
+        this.folderId = folderId;
+        this.customFields = customFields;
     }
 
     public String getName() {
@@ -40,78 +36,27 @@ public class CustomTestCycle {
     }
 
     public String getJiraProjectVersion() {
-        return this.jiraProjectVersion == null
-            ? null
-            : this.jiraProjectVersion.toString();
+        return this.jiraProjectVersion;
     }
 
     public String getFolderId() {
-        return this.folderId == null
-            ? null
-            : this.folderId.toString();
+        return this.folderId;
     }
 
     public String getCustomFields() {
-        return this.customFields.isEmpty()
-            ? null
-            : GsonUtils.getInstance().toJson(this.customFields);
+        return this.customFields;
     }
 
     public boolean isEmpty() {
         return isBlank(name)
             && isBlank(description)
-            && (customFields == null || customFields.size() == 0)
-            && (jiraProjectVersion == null || jiraProjectVersion == 0)
-            && (folderId == null || folderId == 0);
+            && isBlank(customFields)
+            && isBlank(jiraProjectVersion)
+            && isBlank(folderId);
     }
 
-    public void expandEnvVars(final EnvVars envVars) {
-        final String expandedName = envVars.expand(this.getName());
-        final String expandedDescription = envVars.expand(this.getDescription());
-        final String expandedJiraProjectVersion = envVars.expand(this.getJiraProjectVersion());
-        final String expandedFolderId = envVars.expand(this.getFolderId());
-        final String expandedCustomFields = envVars.expand(this.getCustomFields());
-
-        this.name = setStringIfNotBlank(expandedName);
-        this.description = setStringIfNotBlank(expandedDescription);
-        this.jiraProjectVersion = jiraProjectVersion(expandedJiraProjectVersion);
-        this.folderId = jiraProjectVersion(expandedFolderId);
-        this.customFields = convertCustomFieldsToMapIfValid(expandedCustomFields);
-    }
-
-    private String setStringIfNotBlank(final String value) {
-        return isBlank(value)
-            ? null
-            : value;
-    }
-
-    private Long jiraProjectVersion(final String value) {
-        try {
-            return Long.valueOf(value);
-        } catch (final NumberFormatException e) {
-            return null;
-        }
-    }
-
-    private Map<String, Object> convertCustomFieldsToMapIfValid(final String customFieldsJson) {
-        try {
-            /*
-            For security reasons, Jenkins doesn't allow us to marshal
-            properties that are instances of any type of Gson classes.
-            That's why we need to convert Gson's LinkedTreeMap to a
-            HashMap. See https://jenkins.io/redirect/class-filter
-             */
-            return new HashMap<>(
-                GsonUtils.getInstance()
-                    .fromJson(
-                        customFieldsJson,
-                        new TypeToken<Map<String, Object>>() {
-                        }.getType()
-                    )
-            );
-        } catch (final Exception e) {
-            return new HashMap<>();
-        }
+    public ExpandedCustomTestCycle expandEnvVars(final EnvVars envVars) {
+        return new ExpandedCustomTestCycle(this, envVars);
     }
 
     @Override

--- a/src/main/java/com/adaptavist/tm4j/jenkins/extensions/CustomTestCycle.java
+++ b/src/main/java/com/adaptavist/tm4j/jenkins/extensions/CustomTestCycle.java
@@ -4,16 +4,17 @@ import static org.apache.commons.lang.StringUtils.isBlank;
 
 import com.adaptavist.tm4j.jenkins.utils.GsonUtils;
 import com.google.gson.reflect.TypeToken;
+import hudson.EnvVars;
 import java.util.HashMap;
 import java.util.Map;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class CustomTestCycle {
-    protected final String name;
-    protected final String description;
-    protected final Long jiraProjectVersion;
-    protected final Long folderId;
-    protected final Map<String, Object> customFields;
+    protected String name;
+    protected String description;
+    protected Long jiraProjectVersion;
+    protected Long folderId;
+    protected Map<String, Object> customFields;
 
     @DataBoundConstructor
     public CustomTestCycle(
@@ -62,6 +63,20 @@ public class CustomTestCycle {
             && (customFields == null || customFields.size() == 0)
             && (jiraProjectVersion == null || jiraProjectVersion == 0)
             && (folderId == null || folderId == 0);
+    }
+
+    public void expandEnvVars(final EnvVars envVars) {
+        final String expandedName = envVars.expand(this.getName());
+        final String expandedDescription = envVars.expand(this.getDescription());
+        final String expandedJiraProjectVersion = envVars.expand(this.getJiraProjectVersion());
+        final String expandedFolderId = envVars.expand(this.getFolderId());
+        final String expandedCustomFields = envVars.expand(this.getCustomFields());
+
+        this.name = setStringIfNotBlank(expandedName);
+        this.description = setStringIfNotBlank(expandedDescription);
+        this.jiraProjectVersion = jiraProjectVersion(expandedJiraProjectVersion);
+        this.folderId = jiraProjectVersion(expandedFolderId);
+        this.customFields = convertCustomFieldsToMapIfValid(expandedCustomFields);
     }
 
     private String setStringIfNotBlank(final String value) {

--- a/src/main/java/com/adaptavist/tm4j/jenkins/extensions/ExpandedCustomTestCycle.java
+++ b/src/main/java/com/adaptavist/tm4j/jenkins/extensions/ExpandedCustomTestCycle.java
@@ -1,0 +1,119 @@
+package com.adaptavist.tm4j.jenkins.extensions;
+
+import static org.apache.commons.lang.StringUtils.isBlank;
+
+import com.adaptavist.tm4j.jenkins.utils.GsonUtils;
+import com.google.gson.reflect.TypeToken;
+import hudson.EnvVars;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ExpandedCustomTestCycle {
+    protected String name;
+    protected String description;
+    protected Long jiraProjectVersion;
+    protected Long folderId;
+    protected Map<String, Object> customFields;
+
+    public ExpandedCustomTestCycle(final CustomTestCycle customTestCycle, final EnvVars envVars) {
+
+        final String expandedName = envVars.expand(customTestCycle.getName());
+        final String expandedDescription = envVars.expand(customTestCycle.getDescription());
+        final String expandedJiraProjectVersion = envVars.expand(customTestCycle.getJiraProjectVersion());
+        final String expandedFolderId = envVars.expand(customTestCycle.getFolderId());
+        final String expandedCustomFields = envVars.expand(customTestCycle.getCustomFields());
+
+        this.name = setStringIfNotBlank(expandedName);
+        this.description = setStringIfNotBlank(expandedDescription);
+        this.jiraProjectVersion = convertToLongIfPossible(expandedJiraProjectVersion);
+        this.folderId = convertToLongIfPossible(expandedFolderId);
+        this.customFields = convertCustomFieldsToMapIfValid(expandedCustomFields);
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getDescription() {
+        return this.description;
+    }
+
+    public String getJiraProjectVersion() {
+        return this.jiraProjectVersion == null
+            ? null
+            : this.jiraProjectVersion.toString();
+    }
+
+    public String getFolderId() {
+        return this.folderId == null
+            ? null
+            : this.folderId.toString();
+    }
+
+    public String getCustomFields() {
+        return this.customFields.isEmpty()
+            ? null
+            : GsonUtils.getInstance().toJson(this.customFields);
+    }
+
+    public boolean isEmpty() {
+        return isBlank(name)
+            && isBlank(description)
+            && (customFields == null || customFields.size() == 0)
+            && (jiraProjectVersion == null || jiraProjectVersion == 0)
+            && (folderId == null || folderId == 0);
+    }
+
+    private String setStringIfNotBlank(final String value) {
+        return isBlank(value)
+            ? null
+            : value;
+    }
+
+    private Long convertToLongIfPossible(final String value) {
+        try {
+            return Long.valueOf(value);
+        } catch (final NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private Map<String, Object> convertCustomFieldsToMapIfValid(final String customFieldsJson) {
+        try {
+            /*
+            For security reasons, Jenkins doesn't allow us to marshal
+            properties that are instances of any type of Gson classes.
+            That's why we need to convert Gson's LinkedTreeMap to a
+            HashMap. See https://jenkins.io/redirect/class-filter
+             */
+            return new HashMap<>(
+                GsonUtils.getInstance()
+                    .fromJson(
+                        customFieldsJson,
+                        new TypeToken<Map<String, Object>>() {
+                        }.getType()
+                    )
+            );
+        } catch (final Exception e) {
+            return new HashMap<>();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+            "ExpandedCustomTestCycle: {%n" +
+                "    name: %s,%n" +
+                "    description: %s,%n" +
+                "    jiraProjectVersion: %s,%n" +
+                "    folderId: %s,%n" +
+                "    customFields: %s%n" +
+                "}",
+            name,
+            description,
+            jiraProjectVersion,
+            folderId,
+            customFields
+        );
+    }
+}

--- a/src/main/java/com/adaptavist/tm4j/jenkins/extensions/Instance.java
+++ b/src/main/java/com/adaptavist/tm4j/jenkins/extensions/Instance.java
@@ -14,13 +14,13 @@ public interface Instance {
     Boolean isValidCredentials();
 
     HttpResponse<JsonNode> publishCucumberFormatBuildResult(final String projectKey, final Boolean autoCreateTestCases, final File zip,
-                                                            final CustomTestCycle customTestCycle) throws UnirestException;
+                                                            final ExpandedCustomTestCycle expandedCustomTestCycle) throws UnirestException;
 
     HttpResponse<JsonNode> publishCustomFormatBuildResult(final String projectKey, final Boolean autoCreateTestCases, final File zip,
-                                                          final CustomTestCycle customTestCycle) throws UnirestException;
+                                                          final ExpandedCustomTestCycle expandedCustomTestCycle) throws UnirestException;
 
     HttpResponse<JsonNode> publishJUnitFormatBuildResult(final String projectKey, final Boolean autoCreateTestCases, final File zip,
-                                                         final CustomTestCycle customTestCycle) throws UnirestException;
+                                                         final ExpandedCustomTestCycle expandedCustomTestCycle) throws UnirestException;
 
     HttpResponse<String> downloadFeatureFile(final String projectKey) throws UnirestException;
 

--- a/src/main/java/com/adaptavist/tm4j/jenkins/extensions/JiraCloudInstance.java
+++ b/src/main/java/com/adaptavist/tm4j/jenkins/extensions/JiraCloudInstance.java
@@ -23,7 +23,7 @@ public class JiraCloudInstance implements Instance {
     private static final String CUSTOM_FORMAT_ENDPOINT = "{0}/v2/automations/executions/custom";
     private static final String FEATURE_FILES_ENDPOINT = "{0}/v2/automations/testcases";
     private static final String HEALTH_CHECK_ENDPOINT = "{0}/v2/healthcheck";
-    private static final String API_BASE_URL = "https://api.zephyrscale.smartbear.com";
+    private static final String API_BASE_URL = "https://api.zephyrscale-stage.smartbear.com";
 
     private Secret jwt;
     private String name;
@@ -73,26 +73,28 @@ public class JiraCloudInstance implements Instance {
 
     @Override
     public HttpResponse<JsonNode> publishCucumberFormatBuildResult(final String projectKey, final Boolean autoCreateTestCases,
-                                                                   final File zip, final CustomTestCycle customTestCycle)
+                                                                   final File zip, final ExpandedCustomTestCycle expandedCustomTestCycle)
         throws UnirestException {
 
         String url = MessageFormat.format(CUCUMBER_ENDPOINT, API_BASE_URL);
-        return exportResultsFile(url, projectKey, autoCreateTestCases, zip, customTestCycle);
+        return exportResultsFile(url, projectKey, autoCreateTestCases, zip, expandedCustomTestCycle);
     }
 
     @Override
     public HttpResponse<JsonNode> publishCustomFormatBuildResult(final String projectKey, final Boolean autoCreateTestCases, final File zip,
-                                                                 final CustomTestCycle customTestCycle) throws UnirestException {
+                                                                 final ExpandedCustomTestCycle expandedCustomTestCycle)
+        throws UnirestException {
 
         String url = MessageFormat.format(CUSTOM_FORMAT_ENDPOINT, API_BASE_URL);
-        return exportResultsFile(url, projectKey, autoCreateTestCases, zip, customTestCycle);
+        return exportResultsFile(url, projectKey, autoCreateTestCases, zip, expandedCustomTestCycle);
     }
 
     @Override
     public HttpResponse<JsonNode> publishJUnitFormatBuildResult(final String projectKey, final Boolean autoCreateTestCases, final File zip,
-                                                                final CustomTestCycle customTestCycle) throws UnirestException {
+                                                                final ExpandedCustomTestCycle expandedCustomTestCycle)
+        throws UnirestException {
         String url = MessageFormat.format(JUNIT_ENDPOINT, API_BASE_URL);
-        return exportResultsFile(url, projectKey, autoCreateTestCases, zip, customTestCycle);
+        return exportResultsFile(url, projectKey, autoCreateTestCases, zip, expandedCustomTestCycle);
     }
 
     @Override
@@ -134,7 +136,8 @@ public class JiraCloudInstance implements Instance {
     }
 
     private HttpResponse<JsonNode> exportResultsFile(final String url, final String projectKey, final Boolean autoCreateTestCases,
-                                                     final File zip, final CustomTestCycle customTestCycle) throws UnirestException {
+                                                     final File zip, final ExpandedCustomTestCycle expandedCustomTestCycle)
+        throws UnirestException {
         final MultipartBody body = Unirest.post(url)
             .header("Authorization", "Bearer " + getDecryptedJwt())
             .header("zscale-source", "Jenkins Plugin")
@@ -142,8 +145,8 @@ public class JiraCloudInstance implements Instance {
             .queryString("projectKey", projectKey)
             .field("file", zip);
 
-        if (customTestCycle != null && !customTestCycle.isEmpty()) {
-            body.field("testCycle", GsonUtils.getInstance().toJson(customTestCycle), "application/json");
+        if (expandedCustomTestCycle != null && !expandedCustomTestCycle.isEmpty()) {
+            body.field("testCycle", GsonUtils.getInstance().toJson(expandedCustomTestCycle), "application/json");
         }
 
         return body.asJson();

--- a/src/main/java/com/adaptavist/tm4j/jenkins/extensions/JiraCloudInstance.java
+++ b/src/main/java/com/adaptavist/tm4j/jenkins/extensions/JiraCloudInstance.java
@@ -23,7 +23,7 @@ public class JiraCloudInstance implements Instance {
     private static final String CUSTOM_FORMAT_ENDPOINT = "{0}/v2/automations/executions/custom";
     private static final String FEATURE_FILES_ENDPOINT = "{0}/v2/automations/testcases";
     private static final String HEALTH_CHECK_ENDPOINT = "{0}/v2/healthcheck";
-    private static final String API_BASE_URL = "https://api.zephyrscale-stage.smartbear.com";
+    private static final String API_BASE_URL = "https://api.zephyrscale.smartbear.com";
 
     private Secret jwt;
     private String name;

--- a/src/main/java/com/adaptavist/tm4j/jenkins/extensions/JiraInstance.java
+++ b/src/main/java/com/adaptavist/tm4j/jenkins/extensions/JiraInstance.java
@@ -72,7 +72,7 @@ public class JiraInstance implements Instance {
 
     @Override
     public HttpResponse<JsonNode> publishCucumberFormatBuildResult(final String projectKey, final Boolean autoCreateTestCases,
-                                                                   final File zip, final CustomTestCycle customTestCycle)
+                                                                   final File zip, final ExpandedCustomTestCycle expandedCustomTestCycle)
         throws UnirestException {
 
         final String url = MessageFormat.format(CUCUMBER_ENDPOINT, serverAddress, projectKey);
@@ -82,7 +82,7 @@ public class JiraInstance implements Instance {
 
     @Override
     public HttpResponse<JsonNode> publishCustomFormatBuildResult(final String projectKey, final Boolean autoCreateTestCases, final File zip,
-                                                                 final CustomTestCycle customTestCycle)
+                                                                 final ExpandedCustomTestCycle expandedCustomTestCycle)
         throws UnirestException {
 
         final String url = MessageFormat.format(CUSTOM_FORMAT_ENDPOINT, serverAddress, projectKey);
@@ -92,7 +92,7 @@ public class JiraInstance implements Instance {
 
     @Override
     public HttpResponse<JsonNode> publishJUnitFormatBuildResult(final String projectKey, final Boolean autoCreateTestCases, final File zip,
-                                                                final CustomTestCycle customTestCycle) throws UnirestException {
+                                                                final ExpandedCustomTestCycle expandedCustomTestCycle) throws UnirestException {
         throw new RuntimeException("Not implemented for Zephyr Scale Server/DC");
     }
 

--- a/src/main/java/com/adaptavist/tm4j/jenkins/extensions/postbuildactions/TestResultPublisher.java
+++ b/src/main/java/com/adaptavist/tm4j/jenkins/extensions/postbuildactions/TestResultPublisher.java
@@ -81,6 +81,7 @@ public class TestResultPublisher extends Notifier implements SimpleBuildStep {
         TaskListener listener
     ) {
         final PrintStream logger = listener.getLogger();
+        this.customTestCycle.expandEnvVars(envVars);
         publishResults(logger, run, workspace);
     }
 

--- a/src/main/java/com/adaptavist/tm4j/jenkins/http/Tm4jJiraRestClient.java
+++ b/src/main/java/com/adaptavist/tm4j/jenkins/http/Tm4jJiraRestClient.java
@@ -4,7 +4,7 @@ import static com.adaptavist.tm4j.jenkins.utils.Constants.ERROR;
 import static com.adaptavist.tm4j.jenkins.utils.Constants.INFO;
 
 import com.adaptavist.tm4j.jenkins.exception.NoTestCasesFoundException;
-import com.adaptavist.tm4j.jenkins.extensions.CustomTestCycle;
+import com.adaptavist.tm4j.jenkins.extensions.ExpandedCustomTestCycle;
 import com.adaptavist.tm4j.jenkins.extensions.Instance;
 import com.adaptavist.tm4j.jenkins.io.FileReader;
 import com.adaptavist.tm4j.jenkins.io.FileWriter;
@@ -32,7 +32,7 @@ public class Tm4jJiraRestClient {
     }
 
     public void uploadCucumberFile(final String directory, final String filePath, final String projectKey,
-                                   final Boolean autoCreateTestCases, final CustomTestCycle customTestCycle
+                                   final Boolean autoCreateTestCases, final ExpandedCustomTestCycle expandedCustomTestCycle
     ) throws Exception {
 
         final FileReader fileReader = new FileReader();
@@ -45,7 +45,7 @@ public class Tm4jJiraRestClient {
             projectKey,
             autoCreateTestCases,
             file,
-            customTestCycle
+            expandedCustomTestCycle
         );
 
         processUploadingResultsResponse(jsonResponse);
@@ -54,7 +54,7 @@ public class Tm4jJiraRestClient {
     }
 
     public void uploadCustomFormatFile(final String directory, final String projectKey, final Boolean autoCreateTestCases,
-                                       final CustomTestCycle customTestCycle) throws Exception {
+                                       final ExpandedCustomTestCycle expandedCustomTestCycle) throws Exception {
 
         File file = new FileReader().getZipForCustomFormat(directory);
 
@@ -62,7 +62,7 @@ public class Tm4jJiraRestClient {
             projectKey,
             autoCreateTestCases,
             file,
-            customTestCycle
+            expandedCustomTestCycle
         );
 
         processUploadingResultsResponse(jsonResponse);
@@ -71,7 +71,7 @@ public class Tm4jJiraRestClient {
     }
 
     public void uploadJUnitXmlResultFile(final String directory, final String filePath, final String projectKey,
-                                         final Boolean autoCreateTestCases, final CustomTestCycle customTestCycle)
+                                         final Boolean autoCreateTestCases, final ExpandedCustomTestCycle expandedCustomTestCycle)
         throws Exception {
 
         File file = new FileReader().getZip(directory, filePath);
@@ -80,7 +80,7 @@ public class Tm4jJiraRestClient {
             projectKey,
             autoCreateTestCases,
             file,
-            customTestCycle
+            expandedCustomTestCycle
         );
 
         processUploadingResultsResponse(jsonResponse);

--- a/src/test/java/com/adaptavist/tm4j/jenkins/extensions/CustomTestCycleTest.java
+++ b/src/test/java/com/adaptavist/tm4j/jenkins/extensions/CustomTestCycleTest.java
@@ -1,10 +1,10 @@
 package com.adaptavist.tm4j.jenkins.extensions;
 
 
-import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import hudson.EnvVars;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -12,57 +12,19 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 public class CustomTestCycleTest {
 
-    private static Stream<Arguments> isEmptyIfAllValuesAreEitherBlankNullOrHasSizeZero_valueProvider() {
+    private static Stream<Arguments> isEmptyIfAllValuesAreBlank_valueProvider() {
         return Stream.of(
             arguments(null, null, null, null, null),
             arguments("", "", "", "", ""),
-            arguments(" ", " ", "1,5", ".5", "{\"checkbox\": true,}"),
-            arguments(" ", " ", "0", "0", "{}")
+            arguments("  ", "  ", "  ", "  ", "  ")
         );
     }
 
     @ParameterizedTest
-    @NullAndEmptySource
-    @ValueSource(strings = {"  ", "aNumber", "1,5", ".5", "1.", "."})
-    public void jiraProjectVersionAndFolderIdAreSetToNullIfCantBeConvertedToLong(final String idValue) {
-        final CustomTestCycle customTestCycle = new CustomTestCycle(
-            "name",
-            "desc",
-            idValue,
-            idValue,
-            "{\"checkbox\": true}"
-        );
-
-        assertThat(customTestCycle.jiraProjectVersion).isNull();
-        assertThat(customTestCycle.getJiraProjectVersion()).isNull();
-
-        assertThat(customTestCycle.folderId).isNull();
-        assertThat(customTestCycle.getFolderId()).isNull();
-    }
-
-    @ParameterizedTest
-    @NullAndEmptySource
-    @ValueSource(strings = {"  ", "{\"checkbox\": true,}", "{\"checkbox: true}", "{\"checkbox\": true", "{\"checkbox\":}", "{: true}"})
-    public void customFieldsIsSetToEmptyHashIfCantBeParsed(final String customFields) {
-        final CustomTestCycle customTestCycle = new CustomTestCycle(
-            "name",
-            "desc",
-            "1",
-            "2",
-            customFields
-        );
-
-        assertThat(customTestCycle.customFields).isEmpty();
-        assertThat(customTestCycle.getCustomFields()).isNull();
-    }
-
-    @ParameterizedTest
-    @MethodSource("isEmptyIfAllValuesAreEitherBlankNullOrHasSizeZero_valueProvider")
+    @MethodSource("isEmptyIfAllValuesAreBlank_valueProvider")
     public void isEmptyIfAllValuesAreEitherBlankNullOrHasSizeZero(final String name, final String description,
                                                                   final String jiraProjectVersion, final String folderId,
                                                                   final String customFields) {
@@ -83,35 +45,66 @@ public class CustomTestCycleTest {
         final String description = "Description";
         final String jiraProjectVersion = "10001";
         final String folderId = "1234";
-
-        final String customFields = "{\"number\":50,\"single-choice\":\"option1\",\"checkbox\":true,\"userpicker\":\"5f8b5cf2ddfdcb0b8d1028bb\",\"single-line\":\"a text line\",\"datepicker\":\"2021-12-31\",\"decimal\":10.5,\"multi-choice\":[\"choice1\",\"choice2\"],\"multi-line\":\"first line<br />second line\"}";
-
-        final String expectedCustomFieldsJson = "{\"number\":50,\"single-choice\":\"option1\",\"checkbox\":true,\"userpicker\":\"5f8b5cf2ddfdcb0b8d1028bb\",\"single-line\":\"a text line\",\"datepicker\":\"2021-12-31\",\"decimal\":10.5,\"multi-choice\":[\"choice1\",\"choice2\"],\"multi-line\":\"first line\\u003cbr /\\u003esecond line\"}";
+        final String customFields =
+            "{\"number\":50,\"single-choice\":\"option1\",\"checkbox\":true,\"userpicker\":\"5f8b5cf2ddfdcb0b8d1028bb\",\"single-line\":\"a text line\",\"datepicker\":\"2021-12-31\",\"decimal\":10.5,\"multi-choice\":[\"choice1\",\"choice2\"],\"multi-line\":\"first line<br />second line\"}";
 
         final CustomTestCycle customTestCycle =
             new CustomTestCycle(name, description, jiraProjectVersion, folderId, customFields);
-
-        final Map<String, Object> expectedCustomFieldsMap = new HashMap<>();
-        expectedCustomFieldsMap.put("checkbox", true);
-        expectedCustomFieldsMap.put("datepicker", "2021-12-31");
-        expectedCustomFieldsMap.put("number", 50.0);
-        expectedCustomFieldsMap.put("decimal", 10.5);
-        expectedCustomFieldsMap.put("single-choice", "option1");
-        expectedCustomFieldsMap.put("userpicker", "5f8b5cf2ddfdcb0b8d1028bb");
-        expectedCustomFieldsMap.put("single-line", "a text line");
-        expectedCustomFieldsMap.put("multi-choice", asList("choice1", "choice2"));
-        expectedCustomFieldsMap.put("multi-line", "first line<br />second line");
-
-        assertThat(customTestCycle.name).isEqualTo(name);
-        assertThat(customTestCycle.description).isEqualTo(description);
-        assertThat(customTestCycle.jiraProjectVersion).isEqualTo(10001L);
-        assertThat(customTestCycle.folderId).isEqualTo(1234L);
-        assertThat(customTestCycle.customFields).isEqualTo(expectedCustomFieldsMap);
 
         assertThat(customTestCycle.getName()).isEqualTo(name);
         assertThat(customTestCycle.getDescription()).isEqualTo(description);
         assertThat(customTestCycle.getJiraProjectVersion()).isEqualTo(jiraProjectVersion);
         assertThat(customTestCycle.getFolderId()).isEqualTo(folderId);
-        assertThat(customTestCycle.getCustomFields()).isEqualTo(expectedCustomFieldsJson);
+        assertThat(customTestCycle.getCustomFields()).isEqualTo(customFields);
+    }
+
+    @Test
+    public void expandVars() {
+        Map<String, String> env = new HashMap<>();
+        env.put("BUILD_NUMBER", "10");
+        env.put("JENKINS_URL", "http://localhost:8080/jenkins/");
+        env.put("BUILD_ID", "15");
+        env.put("JIRA_PROJECT_VERSION", "10001");
+        env.put("FOLDER_ID", "1234");
+        env.put("CI", "true");
+
+        EnvVars envVars = new EnvVars(env);
+
+        final String name = "Build #${BUILD_NUMBER}";
+        final String description = "Build ID '${BUILD_ID}' ran on ${JENKINS_URL}";
+        final String jiraProjectVersion = "${JIRA_PROJECT_VERSION}";
+        final String folderId = "${FOLDER_ID}";
+        final String customFields = "{\"automated\": ${CI}}";
+
+        final CustomTestCycle customTestCycle = new CustomTestCycle(name, description, jiraProjectVersion, folderId, customFields);
+
+        final ExpandedCustomTestCycle expandedCustomTestCycle = customTestCycle.expandEnvVars(envVars);
+
+        assertThat(expandedCustomTestCycle.getName()).isEqualTo("Build #10");
+        assertThat(expandedCustomTestCycle.getDescription()).isEqualTo("Build ID '15' ran on http://localhost:8080/jenkins/");
+        assertThat(expandedCustomTestCycle.getJiraProjectVersion()).isEqualTo("10001");
+        assertThat(expandedCustomTestCycle.getFolderId()).isEqualTo("1234");
+        assertThat(expandedCustomTestCycle.getCustomFields()).isEqualTo("{\"automated\":true}");
+    }
+
+    @Test
+    public void _toString() {
+        final String name = "Custom Name";
+        final String description = "Description";
+        final String jiraProjectVersion = "10001";
+        final String folderId = "1234";
+        final String customFields =            "{\"number\":50}";
+
+        final CustomTestCycle customTestCycle = new CustomTestCycle(name, description, jiraProjectVersion, folderId, customFields);
+
+        final String expectedToString = "CustomTestCycle: {\n" +
+            "    name: Custom Name,\n" +
+            "    description: Description,\n" +
+            "    jiraProjectVersion: 10001,\n" +
+            "    folderId: 1234,\n" +
+            "    customFields: {\"number\":50}\n" +
+            "}";
+
+        assertThat(customTestCycle.toString()).isEqualTo(expectedToString);
     }
 }

--- a/src/test/java/com/adaptavist/tm4j/jenkins/extensions/ExpandedCustomTestCycleTest.java
+++ b/src/test/java/com/adaptavist/tm4j/jenkins/extensions/ExpandedCustomTestCycleTest.java
@@ -1,0 +1,180 @@
+package com.adaptavist.tm4j.jenkins.extensions;
+
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import hudson.EnvVars;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class ExpandedCustomTestCycleTest {
+
+    private static Stream<Arguments> isEmptyIfAllValuesAreEitherBlankNullOrHasSizeZero_valueProvider() {
+        return Stream.of(
+            arguments(null, null, null, null, null),
+            arguments("", "", "", "", ""),
+            arguments(" ", " ", "1,5", ".5", "{\"checkbox\": true,}"),
+            arguments(" ", " ", "0", "0", "{}")
+        );
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"  ", "aNumber", "1,5", ".5", "1.", "."})
+    public void jiraProjectVersionAndFolderIdAreSetToNullIfCantBeConvertedToLong(final String idValue) {
+        final CustomTestCycle customTestCycle = new CustomTestCycle(
+            "name",
+            "desc",
+            idValue,
+            idValue,
+            "{\"checkbox\": true}"
+        );
+
+        final ExpandedCustomTestCycle expandedCustomTestCycle = new ExpandedCustomTestCycle(customTestCycle, new EnvVars());
+
+        assertThat(expandedCustomTestCycle.jiraProjectVersion).isNull();
+        assertThat(expandedCustomTestCycle.getJiraProjectVersion()).isNull();
+
+        assertThat(expandedCustomTestCycle.folderId).isNull();
+        assertThat(expandedCustomTestCycle.getFolderId()).isNull();
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"  ", "{\"checkbox\": true,}", "{\"checkbox: true}", "{\"checkbox\": true", "{\"checkbox\":}", "{: true}"})
+    public void customFieldsIsSetToEmptyHashIfCantBeParsed(final String customFields) {
+        final CustomTestCycle customTestCycle = new CustomTestCycle(
+            "name",
+            "desc",
+            "1",
+            "2",
+            customFields
+        );
+
+        final ExpandedCustomTestCycle expandedCustomTestCycle = new ExpandedCustomTestCycle(customTestCycle, new EnvVars());
+
+        assertThat(expandedCustomTestCycle.customFields).isEmpty();
+        assertThat(expandedCustomTestCycle.getCustomFields()).isNull();
+    }
+
+    @ParameterizedTest
+    @MethodSource("isEmptyIfAllValuesAreEitherBlankNullOrHasSizeZero_valueProvider")
+    public void isEmptyIfAllValuesAreEitherBlankNullOrHasSizeZero(final String name, final String description,
+                                                                  final String jiraProjectVersion, final String folderId,
+                                                                  final String customFields) {
+        final CustomTestCycle customTestCycle = new CustomTestCycle(
+            name,
+            description,
+            jiraProjectVersion,
+            folderId,
+            customFields
+        );
+
+        final ExpandedCustomTestCycle expandedCustomTestCycle = new ExpandedCustomTestCycle(customTestCycle, new EnvVars());
+
+        assertThat(expandedCustomTestCycle.isEmpty()).isTrue();
+    }
+
+    @Test
+    public void validCustomTestCycle() {
+        final String name = "Custom Name";
+        final String description = "Description";
+        final String jiraProjectVersion = "10001";
+        final String folderId = "1234";
+
+        final String customFields =
+            "{\"number\":50,\"single-choice\":\"option1\",\"checkbox\":true,\"userpicker\":\"5f8b5cf2ddfdcb0b8d1028bb\",\"single-line\":\"a text line\",\"datepicker\":\"2021-12-31\",\"decimal\":10.5,\"multi-choice\":[\"choice1\",\"choice2\"],\"multi-line\":\"first line<br />second line\"}";
+
+        final String expectedCustomFieldsJson =
+            "{\"number\":50,\"single-choice\":\"option1\",\"checkbox\":true,\"userpicker\":\"5f8b5cf2ddfdcb0b8d1028bb\",\"single-line\":\"a text line\",\"datepicker\":\"2021-12-31\",\"decimal\":10.5,\"multi-choice\":[\"choice1\",\"choice2\"],\"multi-line\":\"first line\\u003cbr /\\u003esecond line\"}";
+
+        final CustomTestCycle customTestCycle =
+            new CustomTestCycle(name, description, jiraProjectVersion, folderId, customFields);
+
+        final ExpandedCustomTestCycle expandedCustomTestCycle = new ExpandedCustomTestCycle(customTestCycle, new EnvVars());
+
+        final Map<String, Object> expectedCustomFieldsMap = new HashMap<>();
+        expectedCustomFieldsMap.put("checkbox", true);
+        expectedCustomFieldsMap.put("datepicker", "2021-12-31");
+        expectedCustomFieldsMap.put("number", 50.0);
+        expectedCustomFieldsMap.put("decimal", 10.5);
+        expectedCustomFieldsMap.put("single-choice", "option1");
+        expectedCustomFieldsMap.put("userpicker", "5f8b5cf2ddfdcb0b8d1028bb");
+        expectedCustomFieldsMap.put("single-line", "a text line");
+        expectedCustomFieldsMap.put("multi-choice", asList("choice1", "choice2"));
+        expectedCustomFieldsMap.put("multi-line", "first line<br />second line");
+
+        assertThat(expandedCustomTestCycle.name).isEqualTo(name);
+        assertThat(expandedCustomTestCycle.description).isEqualTo(description);
+        assertThat(expandedCustomTestCycle.jiraProjectVersion).isEqualTo(10001L);
+        assertThat(expandedCustomTestCycle.folderId).isEqualTo(1234L);
+        assertThat(expandedCustomTestCycle.customFields).isEqualTo(expectedCustomFieldsMap);
+
+        assertThat(expandedCustomTestCycle.getName()).isEqualTo(name);
+        assertThat(expandedCustomTestCycle.getDescription()).isEqualTo(description);
+        assertThat(expandedCustomTestCycle.getJiraProjectVersion()).isEqualTo(jiraProjectVersion);
+        assertThat(expandedCustomTestCycle.getFolderId()).isEqualTo(folderId);
+        assertThat(expandedCustomTestCycle.getCustomFields()).isEqualTo(expectedCustomFieldsJson);
+    }
+
+    @Test
+    public void expandVars() {
+        Map<String, String> env = new HashMap<>();
+        env.put("BUILD_NUMBER", "10");
+        env.put("JENKINS_URL", "http://localhost:8080/jenkins/");
+        env.put("BUILD_ID", "15");
+        env.put("JIRA_PROJECT_VERSION", "10001");
+        env.put("FOLDER_ID", "1234");
+        env.put("CI", "true");
+
+        EnvVars envVars = new EnvVars(env);
+
+        final String name = "Build #${BUILD_NUMBER}";
+        final String description = "Build ID '${BUILD_ID}' ran on ${JENKINS_URL}";
+        final String jiraProjectVersion = "${JIRA_PROJECT_VERSION}";
+        final String folderId = "${FOLDER_ID}";
+        final String customFields = "{\"automated\": ${CI}}";
+
+        final CustomTestCycle customTestCycle = new CustomTestCycle(name, description, jiraProjectVersion, folderId, customFields);
+
+        final ExpandedCustomTestCycle expandedCustomTestCycle = new ExpandedCustomTestCycle(customTestCycle, envVars);
+
+        assertThat(expandedCustomTestCycle.getName()).isEqualTo("Build #10");
+        assertThat(expandedCustomTestCycle.getDescription()).isEqualTo("Build ID '15' ran on http://localhost:8080/jenkins/");
+        assertThat(expandedCustomTestCycle.getJiraProjectVersion()).isEqualTo("10001");
+        assertThat(expandedCustomTestCycle.getFolderId()).isEqualTo("1234");
+        assertThat(expandedCustomTestCycle.getCustomFields()).isEqualTo("{\"automated\":true}");
+    }
+
+    @Test
+    public void _toString() {
+        final String name = "Custom Name";
+        final String description = "Description";
+        final String jiraProjectVersion = "10001";
+        final String folderId = "1234";
+        final String customFields = "{\"number\":50}";
+
+        final CustomTestCycle customTestCycle = new CustomTestCycle(name, description, jiraProjectVersion, folderId, customFields);
+
+        final ExpandedCustomTestCycle expandedCustomTestCycle = customTestCycle.expandEnvVars(new EnvVars());
+
+        final String expectedToString = "ExpandedCustomTestCycle: {\n" +
+            "    name: Custom Name,\n" +
+            "    description: Description,\n" +
+            "    jiraProjectVersion: 10001,\n" +
+            "    folderId: 1234,\n" +
+            "    customFields: {number=50.0}\n" +
+            "}";
+
+        assertThat(expandedCustomTestCycle.toString()).isEqualTo(expectedToString);
+    }
+}

--- a/src/test/java/com/adaptavist/tm4j/jenkins/extensions/JiraCloudInstanceTest.java
+++ b/src/test/java/com/adaptavist/tm4j/jenkins/extensions/JiraCloudInstanceTest.java
@@ -22,6 +22,7 @@ import com.mashape.unirest.request.GetRequest;
 import com.mashape.unirest.request.HttpRequest;
 import com.mashape.unirest.request.HttpRequestWithBody;
 import com.mashape.unirest.request.body.MultipartBody;
+import hudson.EnvVars;
 import hudson.util.Secret;
 import java.io.File;
 import org.apache.http.client.HttpClient;
@@ -56,7 +57,7 @@ public class JiraCloudInstanceTest {
     private static final String VALID_JWT_WITHOUT_BASE_URL =
         "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2MzcxNDkyNzMsImV4cCI6MTYzNzE1Mjg3MywiaXNzIjoiY29tLmthbm9haC50ZXN0LW1hbmFnZXIiLCJzdWIiOiJjbGllbnQta2V5IiwiY29udGV4dCI6eyJ1c2VyIjp7ImFjY291bnRJZCI6IjRmN2I3ZGYxZGRmZWRjOWI3ZTA5MzdiYiJ9fX0.ZJBPnhJx_BwjYtIsFC3FnseIDziHV0uI4VxOECMFdiM";
 
-    private static CustomTestCycle getCustomTestCycle(final String name) {
+    private static ExpandedCustomTestCycle getExpandedCustomTestCycle(final String name) {
         final String description = "Description";
         final String jiraProjectVersion = "10001";
         final String folderId = "1234";
@@ -64,7 +65,9 @@ public class JiraCloudInstanceTest {
         final String customFields =
             "{\"number\":50,\"single-choice\":\"option1\",\"checkbox\":true,\"userpicker\":\"5f8b5cf2ddfdcb0b8d1028bb\",\"single-line\":\"a text line\",\"datepicker\":\"2021-12-31\",\"decimal\":10.5,\"multi-choice\":[\"choice1\",\"choice2\"],\"multi-line\":\"first line<br />second line\"}";
 
-        return new CustomTestCycle(name, description, jiraProjectVersion, folderId, customFields);
+        final CustomTestCycle customTestCycle = new CustomTestCycle(name, description, jiraProjectVersion, folderId, customFields);
+
+        return new ExpandedCustomTestCycle(customTestCycle, new EnvVars());
     }
 
     @Test
@@ -127,7 +130,7 @@ public class JiraCloudInstanceTest {
     public void publishCucumberFormatBuildResult_withCustomTestCycle() throws UnirestException {
         try (final MockedStatic<Unirest> unirest = mockStatic(Unirest.class)) {
             final File zip = mock(File.class);
-            final CustomTestCycle customTestCycle = getCustomTestCycle("Cucumber Build");
+            final ExpandedCustomTestCycle expandedCustomTestCycle = getExpandedCustomTestCycle("Cucumber Build");
             final HttpClient httpClient = mock(HttpClient.class);
 
             final JiraCloudInstance jiraCloudInstance = getValidJiraCloudInstance();
@@ -145,12 +148,12 @@ public class JiraCloudInstanceTest {
             when(httpRequestWithBody.queryString("projectKey", PROJECT_KEY)).thenReturn(httpRequestWithBody);
             when(httpRequestWithBody.field("file", zip)).thenReturn(multipartBody);
 
-            when(multipartBody.field("testCycle", GsonUtils.getInstance().toJson(customTestCycle), "application/json")).thenReturn(
+            when(multipartBody.field("testCycle", GsonUtils.getInstance().toJson(expandedCustomTestCycle), "application/json")).thenReturn(
                 multipartBody);
 
             when(multipartBody.asJson()).thenReturn(httpResponseJsonNode);
 
-            jiraCloudInstance.publishCucumberFormatBuildResult(PROJECT_KEY, true, zip, customTestCycle);
+            jiraCloudInstance.publishCucumberFormatBuildResult(PROJECT_KEY, true, zip, expandedCustomTestCycle);
 
             verifyNoMoreInteractions(zip);
             verifyNoMoreInteractions(httpClient);
@@ -201,7 +204,7 @@ public class JiraCloudInstanceTest {
     public void publishCustomFormatBuildResult_withCustomTestCycle() throws UnirestException {
         try (final MockedStatic<Unirest> unirest = mockStatic(Unirest.class)) {
             final File zip = mock(File.class);
-            final CustomTestCycle customTestCycle = getCustomTestCycle("Custom Format Build");
+            final ExpandedCustomTestCycle expandedCustomTestCycle = getExpandedCustomTestCycle("Custom Format Build");
             final HttpClient httpClient = mock(HttpClient.class);
 
             final JiraCloudInstance jiraCloudInstance = getValidJiraCloudInstance();
@@ -219,12 +222,13 @@ public class JiraCloudInstanceTest {
             when(httpRequestWithBody.queryString("projectKey", PROJECT_KEY)).thenReturn(httpRequestWithBody);
             when(httpRequestWithBody.field("file", zip)).thenReturn(multipartBody);
 
-            when(multipartBody.field("testCycle", GsonUtils.getInstance().toJson(customTestCycle), "application/json")).thenReturn(
+            when(multipartBody.field("testCycle", GsonUtils.getInstance().toJson(expandedCustomTestCycle), "application/json")).thenReturn(
                 multipartBody);
 
             when(multipartBody.asJson()).thenReturn(httpResponse);
 
-            HttpResponse<JsonNode> actualResponse = jiraCloudInstance.publishCustomFormatBuildResult(PROJECT_KEY, true, zip, customTestCycle);
+            HttpResponse<JsonNode> actualResponse =
+                jiraCloudInstance.publishCustomFormatBuildResult(PROJECT_KEY, true, zip, expandedCustomTestCycle);
 
             assertThat(actualResponse).isEqualTo(httpResponse);
 
@@ -277,7 +281,7 @@ public class JiraCloudInstanceTest {
     public void publishJUnitFormatBuildResult_withCustomTestCycle() throws UnirestException {
         try (final MockedStatic<Unirest> unirest = mockStatic(Unirest.class)) {
             final File zip = mock(File.class);
-            final CustomTestCycle customTestCycle = getCustomTestCycle("JUnit Build");
+            final ExpandedCustomTestCycle expandedCustomTestCycle = getExpandedCustomTestCycle("JUnit Build");
             final HttpClient httpClient = mock(HttpClient.class);
 
             final JiraCloudInstance jiraCloudInstance = getValidJiraCloudInstance();
@@ -295,12 +299,13 @@ public class JiraCloudInstanceTest {
             when(httpRequestWithBody.queryString("projectKey", PROJECT_KEY)).thenReturn(httpRequestWithBody);
             when(httpRequestWithBody.field("file", zip)).thenReturn(multipartBody);
 
-            when(multipartBody.field("testCycle", GsonUtils.getInstance().toJson(customTestCycle), "application/json")).thenReturn(
+            when(multipartBody.field("testCycle", GsonUtils.getInstance().toJson(expandedCustomTestCycle), "application/json")).thenReturn(
                 multipartBody);
 
             when(multipartBody.asJson()).thenReturn(httpResponse);
 
-            HttpResponse<JsonNode> actualResponse = jiraCloudInstance.publishJUnitFormatBuildResult(PROJECT_KEY, true, zip, customTestCycle);
+            HttpResponse<JsonNode> actualResponse =
+                jiraCloudInstance.publishJUnitFormatBuildResult(PROJECT_KEY, true, zip, expandedCustomTestCycle);
 
             assertThat(actualResponse).isEqualTo(httpResponse);
 

--- a/src/test/java/com/adaptavist/tm4j/jenkins/extensions/JiraInstanceTest.java
+++ b/src/test/java/com/adaptavist/tm4j/jenkins/extensions/JiraInstanceTest.java
@@ -18,6 +18,7 @@ import com.mashape.unirest.request.GetRequest;
 import com.mashape.unirest.request.HttpRequest;
 import com.mashape.unirest.request.HttpRequestWithBody;
 import com.mashape.unirest.request.body.MultipartBody;
+import hudson.EnvVars;
 import hudson.util.Secret;
 import java.io.File;
 import java.util.stream.Stream;
@@ -46,7 +47,7 @@ public class JiraInstanceTest {
     private static final String FEATURE_FILES_ENDPOINT = "rest/atm/1.0/automation/testcases";
     private static final String HEALTH_CHECK_ENDPOINT = "rest/atm/1.0/healthcheck/";
 
-    private static CustomTestCycle getCustomTestCycle() {
+    private static ExpandedCustomTestCycle getExpandedTestCycle() {
         final String description = "Description";
         final String jiraProjectVersion = "10001";
         final String folderId = "1234";
@@ -54,12 +55,13 @@ public class JiraInstanceTest {
         final String customFields =
             "{\"number\":50,\"single-choice\":\"option1\",\"checkbox\":true,\"userpicker\":\"5f8b5cf2ddfdcb0b8d1028bb\",\"single-line\":\"a text line\",\"datepicker\":\"2021-12-31\",\"decimal\":10.5,\"multi-choice\":[\"choice1\",\"choice2\"],\"multi-line\":\"first line<br />second line\"}";
 
-        return new CustomTestCycle("Custom Build", description, jiraProjectVersion, folderId, customFields);
+        final CustomTestCycle customTestCycle =  new CustomTestCycle("Custom Build", description, jiraProjectVersion, folderId, customFields);
+        return new ExpandedCustomTestCycle(customTestCycle, new EnvVars());
     }
 
     private static Stream<Arguments> customTestCycleArgumentProvider() {
         return Stream.of(
-            arguments(getCustomTestCycle())
+            arguments(getExpandedTestCycle())
         );
     }
 
@@ -208,7 +210,7 @@ public class JiraInstanceTest {
     @ParameterizedTest
     @NullSource
     @MethodSource("customTestCycleArgumentProvider")
-    public void publishCucumberFormatBuildResult(final CustomTestCycle customTestCycle) throws UnirestException {
+    public void publishCucumberFormatBuildResult(final ExpandedCustomTestCycle expandedCustomTestCycle) throws UnirestException {
         try (final MockedStatic<Unirest> unirest = mockStatic(Unirest.class)) {
             final File zip = mock(File.class);
             final HttpClient httpClient = mock(HttpClient.class);
@@ -227,7 +229,7 @@ public class JiraInstanceTest {
             when(httpRequestWithBody.field("file", zip)).thenReturn(multipartBody);
             when(multipartBody.asJson()).thenReturn(httpResponse);
 
-            HttpResponse<JsonNode> actualResponse = jiraInstance.publishCucumberFormatBuildResult(PROJECT_KEY, true, zip, customTestCycle);
+            HttpResponse<JsonNode> actualResponse = jiraInstance.publishCucumberFormatBuildResult(PROJECT_KEY, true, zip, expandedCustomTestCycle);
 
             assertThat(actualResponse).isEqualTo(httpResponse);
 
@@ -242,7 +244,7 @@ public class JiraInstanceTest {
     @ParameterizedTest
     @NullSource
     @MethodSource("customTestCycleArgumentProvider")
-    public void publishCustomFormatBuildResult(final CustomTestCycle customTestCycle) throws UnirestException {
+    public void publishCustomFormatBuildResult(final ExpandedCustomTestCycle expandedCustomTestCycle) throws UnirestException {
         try (final MockedStatic<Unirest> unirest = mockStatic(Unirest.class)) {
             final File zip = mock(File.class);
             final HttpClient httpClient = mock(HttpClient.class);
@@ -261,7 +263,7 @@ public class JiraInstanceTest {
             when(httpRequestWithBody.field("file", zip)).thenReturn(multipartBody);
             when(multipartBody.asJson()).thenReturn(httpResponse);
 
-            HttpResponse<JsonNode> actualResponse = jiraInstance.publishCustomFormatBuildResult(PROJECT_KEY, true, zip, customTestCycle);
+            HttpResponse<JsonNode> actualResponse = jiraInstance.publishCustomFormatBuildResult(PROJECT_KEY, true, zip, expandedCustomTestCycle);
 
             assertThat(actualResponse).isEqualTo(httpResponse);
 


### PR DESCRIPTION
I released version 3.1.0 without this feature but it's definitely something we need to support.