### PR TITLE
TM4J-4657: Added support for Windows paths when uploading Cucumber results

### DIFF
--- a/src/main/java/com/adaptavist/tm4j/jenkins/cucumber/CucumberFileProcessor.java
+++ b/src/main/java/com/adaptavist/tm4j/jenkins/cucumber/CucumberFileProcessor.java
@@ -27,7 +27,7 @@ public class CucumberFileProcessor {
     private static String getTmpDirectory(String directory) {
         String fileSeparator = FileSystems.getDefault().getSeparator();
         String tmpDirectoryName = directory + (directory.endsWith(fileSeparator) ? "" : fileSeparator);
-        return tmpDirectoryName + "target/cucumber_tmp/";
+        return tmpDirectoryName + "target" + fileSeparator + "cucumber_tmp" + fileSeparator;
     }
 
     void setTmpDirectory(String directory){

--- a/src/main/java/com/adaptavist/tm4j/jenkins/extensions/postbuildactions/TestResultPublisher.java
+++ b/src/main/java/com/adaptavist/tm4j/jenkins/extensions/postbuildactions/TestResultPublisher.java
@@ -29,6 +29,7 @@ import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.FileSystems;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
@@ -42,7 +43,7 @@ import org.kohsuke.stapler.verb.POST;
 
 public class TestResultPublisher extends Notifier implements SimpleBuildStep {
 
-    private final Boolean customizeTestCycle;
+    private final boolean customizeTestCycle;
     private final CustomTestCycle customTestCycle;
     private String serverAddress;
     private String projectKey;
@@ -147,13 +148,14 @@ public class TestResultPublisher extends Notifier implements SimpleBuildStep {
     }
 
     private String getDirectory(FilePath workspace, Run<?, ?> run) throws IOException, InterruptedException {
+        final String fileSeparator = FileSystems.getDefault().getSeparator();
         if (workspace.isRemote()) {
             FilePath path = new FilePath(run.getRootDir());
             workspace.copyRecursiveTo(this.filePath, path);
-            return run.getRootDir() + "/";
+            return run.getRootDir() + fileSeparator;
         }
 
-        return workspace.getRemote() + "/";
+        return workspace.getRemote() + fileSeparator;
     }
 
     @Override


### PR DESCRIPTION
Fixes the support issue: https://smartbear.atlassian.net/browse/TM4J-4657

We no longer have hardcoded paths in our code responsible for uploading Cucumber results.
Tested in Windows, folder structure was created sucessfully:
<img width="900" alt="Screenshot 2022-03-01 at 18 41 40" src="https://user-images.githubusercontent.com/19436023/156327734-fa5bae87-0c54-4083-8566-3aa8b694f627.png">
<img width="900" alt="Screenshot 2022-03-01 at 18 41 31" src="https://user-images.githubusercontent.com/19436023/156327748-4045f17d-c941-4841-ba3c-bc3dc2e158a3.png">
