### PR TITLE
Fix Manage Jenkins unable to save

### DIFF
--- a/src/main/java/com/adaptavist/tm4j/jenkins/extensions/configuration/Tm4jGlobalConfiguration.java
+++ b/src/main/java/com/adaptavist/tm4j/jenkins/extensions/configuration/Tm4jGlobalConfiguration.java
@@ -53,7 +53,7 @@ public class Tm4jGlobalConfiguration extends GlobalConfiguration {
 
             if(formJiraInstances instanceof JSONArray) {
                 jiraInstancesList = formData.getJSONArray(JIRA_INSTANCES);
-            } else {
+            } else if(formJiraInstances instanceof JSONObject) {
                 jiraInstancesList.add(formData.getJSONObject(JIRA_INSTANCES));
             }
 


### PR DESCRIPTION
In 3.3.0,  if no servers are defined in Manage Jenkins --> Configure System, then an error occurs when Save is clicked:

![image](https://user-images.githubusercontent.com/7984422/187479854-68fa6946-ef27-422d-8c4e-f8db01c14953.png)

Have tested fix locally