### PR TITLE
JQA-0: Logging fixed when cucumber upload fails

### DIFF
--- a/src/main/java/com/adaptavist/tm4j/jenkins/extensions/Instance.java
+++ b/src/main/java/com/adaptavist/tm4j/jenkins/extensions/Instance.java
@@ -45,7 +45,7 @@ public abstract class Instance {
         try {
             return body.asJson();
         } catch (final UnirestException e) {
-            throw new RuntimeException(body.asString().getBody());
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/test/java/com/adaptavist/tm4j/jenkins/extensions/JiraServerInstanceTest.java
+++ b/src/test/java/com/adaptavist/tm4j/jenkins/extensions/JiraServerInstanceTest.java
@@ -357,6 +357,21 @@ public class JiraServerInstanceTest {
 
     }
 
+    @Test
+    public void getBodyAsJsonOrThrowExceptionWithBody() throws UnirestException {
+        // given
+        final MultipartBody multipartBody = mock(MultipartBody.class);
+
+        when(multipartBody.asJson()).thenThrow(new UnirestException("Something went terribly wrong!"));
+
+        final JiraServerInstance jiraServerInstance = this.getValidJiraInstance();
+
+        // when then
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> jiraServerInstance.getBodyAsJsonOrThrowExceptionWithBody(multipartBody))
+                .withMessageContaining("Something went terribly wrong!");
+    }
+
     private JiraServerInstance getValidJiraInstance() {
         return new JiraServerInstance(BASE_URL, USERNAME, getSecret());
     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

This is a small improvement in logging that would enable us to see more error output when sending of cucumber results fails.

Before it was logging just a request body, which didn't make any sense.
