### PR TITLE
Release version 3.3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <description>Integration with Zephyr Scale (by SmartBear), for automatic publishing of test results.</description>
     <groupId>com.adaptavist</groupId>
     <artifactId>tm4j-automation</artifactId>
-    <version>3.3.2</version>
+    <version>3.3.3</version>
     <packaging>hpi</packaging>
 
     <licenses>


### PR DESCRIPTION
This PR releases version `3.3.3` with the following changes:
* #59: Bump up the version of `org.json:json` to address the vulnerability [here](https://github.com/jenkinsci/tm4j-automation-plugin/security/dependabot/1)
* #57: Improve logging to identify which Cloud instance a user tried to connect to