### PR TITLE
TMCJSUP-8670: adding logs including content for debug purposes

### DIFF
--- a/src/main/java/com/adaptavist/tm4j/jenkins/exception/PrintingZipFileContentException.java
+++ b/src/main/java/com/adaptavist/tm4j/jenkins/exception/PrintingZipFileContentException.java
@@ -1,0 +1,7 @@
+package com.adaptavist.tm4j.jenkins.exception;
+
+public class PrintingZipFileContentException extends RuntimeException{
+    public PrintingZipFileContentException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/adaptavist/tm4j/jenkins/http/Tm4jJiraRestClient.java
+++ b/src/main/java/com/adaptavist/tm4j/jenkins/http/Tm4jJiraRestClient.java
@@ -109,9 +109,11 @@ public class Tm4jJiraRestClient {
             StringBuilder builder = new StringBuilder();
             while (entries.hasMoreElements()) {
                 ZipEntry entry = entries.nextElement();
-                builder.append(String.format("file with name: '%s' and content:\n[start content]", entry.getName()));
-                InputStream inputStream = zipFile.getInputStream(entry);
-                builder.append(IOUtils.toString(inputStream, StandardCharsets.UTF_8.name()));
+                builder.append(String.format("file with name: '%s' and content:\n", entry.getName()));
+                try (InputStream inputStream = zipFile.getInputStream(entry)) {
+                    builder.append("[start content]");
+                    builder.append(IOUtils.toString(inputStream, StandardCharsets.UTF_8.name()));
+                }
                 builder.append("[end content]:");
             }
             return builder.toString();

--- a/src/main/java/com/adaptavist/tm4j/jenkins/utils/ZipHandler.java
+++ b/src/main/java/com/adaptavist/tm4j/jenkins/utils/ZipHandler.java
@@ -27,7 +27,7 @@ public class ZipHandler {
                         builder.append("[start content]%n");
                         builder.append(IOUtils.toString(inputStream, StandardCharsets.UTF_8));
                     } catch (IOException e) {
-                        builder.append("not possible to reach the content");
+                        builder.append("not possible to read the content");
                     }
                     builder.append("%n[end content]%n");
                 }

--- a/src/main/java/com/adaptavist/tm4j/jenkins/utils/ZipHandler.java
+++ b/src/main/java/com/adaptavist/tm4j/jenkins/utils/ZipHandler.java
@@ -33,7 +33,7 @@ public class ZipHandler {
                 }
                 return builder.toString();
             } catch (Exception e) {
-                throw new PrintingZipFileContentException(String.format("was not possible to reach the content for file %s", file.getAbsolutePath(), e));
+                throw new PrintingZipFileContentException(String.format("was not possible to read the content for file %s", file.getAbsolutePath(), e));
             }
         } else {
             throw new PrintingZipFileContentException(String.format("the temporal zip file:%s does not exist", file.getAbsolutePath()));

--- a/src/main/java/com/adaptavist/tm4j/jenkins/utils/ZipHandler.java
+++ b/src/main/java/com/adaptavist/tm4j/jenkins/utils/ZipHandler.java
@@ -1,5 +1,6 @@
 package com.adaptavist.tm4j.jenkins.utils;
 
+import com.adaptavist.tm4j.jenkins.exception.PrintingZipFileContentException;
 import org.apache.commons.io.IOUtils;
 
 import java.io.File;
@@ -32,10 +33,10 @@ public class ZipHandler {
                 }
                 return builder.toString();
             } catch (Exception e) {
-                throw new RuntimeException(String.format("was not possible to reach the content for file %s", file.getAbsolutePath(), e));
+                throw new PrintingZipFileContentException(String.format("was not possible to reach the content for file %s", file.getAbsolutePath(), e));
             }
         } else {
-            throw new RuntimeException(String.format("the temporal zip file:%s does not exist", file.getAbsolutePath()));
+            throw new PrintingZipFileContentException(String.format("the temporal zip file:%s does not exist", file.getAbsolutePath()));
         }
     }
 }

--- a/src/main/java/com/adaptavist/tm4j/jenkins/utils/ZipHandler.java
+++ b/src/main/java/com/adaptavist/tm4j/jenkins/utils/ZipHandler.java
@@ -1,0 +1,41 @@
+package com.adaptavist.tm4j.jenkins.utils;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Enumeration;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+public class ZipHandler {
+    private ZipHandler(){
+        //no need of instance
+    }
+    public static String getContentFromFilesInZip(File file) {
+        if (file.exists()) {
+            try (ZipFile zipFile = new ZipFile(file)) {
+                Enumeration<? extends ZipEntry> entries = zipFile.entries();
+                StringBuilder builder = new StringBuilder();
+                while (entries.hasMoreElements()) {
+                    ZipEntry entry = entries.nextElement();
+                    builder.append(String.format("file with name: '%s' and content:%n", entry.getName()));
+                    try (InputStream inputStream = zipFile.getInputStream(entry)) {
+                        builder.append("[start content]%n");
+                        builder.append(IOUtils.toString(inputStream, StandardCharsets.UTF_8));
+                    } catch (IOException e) {
+                        builder.append("not possible to reach the content");
+                    }
+                    builder.append("%n[end content]%n");
+                }
+                return builder.toString();
+            } catch (Exception e) {
+                throw new RuntimeException(String.format("was not possible to reach the content for file %s", file.getAbsolutePath(), e));
+            }
+        } else {
+            throw new RuntimeException(String.format("the temporal zip file:%s does not exist", file.getAbsolutePath()));
+        }
+    }
+}


### PR DESCRIPTION
Adding logs on error when sending files to ZS and not removing the temporal zip file that is used to send information to ZS for troubleshooting purposes.

So when an error occurs the result looks like the following:
```
[Zephyr Scale] [ERROR] Error: 

{
  "errorCode": 400,
  "message": "Unable to construct JUnit results. Cause: Unexpected character 'a' (code 97) in prolog; expected '<'\n at [row,col {unknown-source}]: [1,1]",
  "status": "Bad Request"
}

[Zephyr Scale] [ERROR] Test Cycle was not created 
[Zephyr Scale] [ERROR] An error was raised, the file will not be removed for troubleshooting purposes, when trying to send file on path:'/var/folders/4p/rs26rqyj2kl81px2_4btwpqh0000gs/T/tm4j2552859445551997471.zip' with content:
 file with name: '/Users/victor.martinez/workspace/tm4j-automation-plugin/work/workspace/sometest/any.xml' and content:
[start content]
any xml " that could" be that" is wrong
[end content]
file with name: '/Users/victor.martinez/workspace/tm4j-automation-plugin/work/workspace/sometest/any2.xml' and content:
[start content]
any xml2 " that could2" be that" is wrong
[end content]
```

and the zip file used to send to ZS exists in the path

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
